### PR TITLE
ci: run e2e/lighthouse tests on deployment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postStartCommand": "pnpm install --frozen-lockfile",
+  "postStartCommand": "pnpm install --frozen-lockfile && pnpm playwright install --with-deps",
   "containerEnv": {
     "HOSTNAME": "0.0.0.0"
   },

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,8 +10,7 @@ jobs:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     permissions:
       contents: read
-    env:
-      DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,14 @@ jobs:
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:
+          runs: 5
           urls: |
             ${{ github.event.deployment_status.environment_url }}
           budgetPath: ./budget.json
+          configPath: ./lighthouserc.json
+
+      - name: Display Lighthouse results
+        uses: manrueda/lighthouse-report-action@master
+        with:
+          reports: .lighthouseci
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,9 @@ jobs:
     env:
       DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,21 @@
+name: E2E Tests
+
+on:
+  deployment_status:
+
+jobs:
+  lighthouse:
+    name: Run lighthouse
+    runs-on: ubuntu-latest
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    permissions:
+      contents: read
+    env:
+      DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
+    steps:
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            ${{ github.event.deployment_status.environment_url }}
+          budgetPath: ./budget.json

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,6 @@ jobs:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,9 +22,3 @@ jobs:
             ${{ github.event.deployment_status.environment_url }}
           budgetPath: ./budget.json
           configPath: ./lighthouserc.json
-
-      - name: Display Lighthouse results
-        uses: manrueda/lighthouse-report-action@master
-        with:
-          reports: .lighthouseci
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: Local Tests
 
 on:
   pull_request:

--- a/budget.json
+++ b/budget.json
@@ -1,0 +1,33 @@
+[
+  {
+    "path": "/",
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 250
+      },
+      {
+        "resourceType": "image",
+        "budget": 150
+      },
+      {
+        "resourceType": "script",
+        "budget": 50
+      }
+    ],
+    "timings": [
+      {
+        "metric": "interactive",
+        "budget": 3000
+      },
+      {
+        "metric": "first-contentful-paint",
+        "budget": 1500
+      },
+      {
+        "metric": "largest-contentful-paint",
+        "budget": 2500
+      }
+    ]
+  }
+]

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,6 @@
 {
   "ci": {
     "collect": {
-      "numberOfRuns": 5,
       "settings": {
         "preset": "desktop"
       }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,13 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 5,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --fix . && biome check --write --unsafe",
-    "test": "playwright test",
-    "postinstall": "playwright install --with-deps"
+    "test": "playwright test"
   },
   "engines": {
     "node": ">=22 <23"


### PR DESCRIPTION
Close #12 

Vercel のデプロイが完了すると、lighthouse が動くようにする
今後 e2e テストも同様に CI を通す土台作り